### PR TITLE
Function types #23

### DIFF
--- a/src/haxe/languageservices/grammar/HaxeGrammar.hx
+++ b/src/haxe/languageservices/grammar/HaxeGrammar.hx
@@ -196,7 +196,10 @@ class HaxeGrammar extends Grammar<Node> {
         var typeName = seq([identifier, optType], buildNode('NIdWithType'));
         var typeNameList = list(typeName, ',', 0, false, rlist);
         
-        var anonType = seq([ '{', opt(typeNameList), '}' ], rlist);
+        var typeNameReq = seq([identifier, reqType], rlist);
+        var typeNameReqList = list(typeNameReq, ',', 1, false, rlist);
+        
+        var anonType = seq([ '{', opt(typeNameReqList), '}' ], rlist);
         var genericsType = seq([ identifier, opt(seqi(['<', type, '>'])) ], rlist);
         var baseType = any([ anonType, genericsType ]);
         


### PR DESCRIPTION
Seems to parse `var foo : {a : Int, b : String} -> Array<Array<{}>> -> Int;` ok
The example code has some validation issues for `a` and `b` however (Type name should start with an uppercase letter), but I guess that's something further down..
